### PR TITLE
Refine repo config, rulesets, and docs

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -14,7 +14,7 @@ repository:
 
   # A comma-separated list of topics to set on the repo
   # See https://github.com/topics
-  topics: community-health, github, github-config, github-profile, template
+  topics: community-health-files, github-config, probot-settings, template-repository
 
   #─────────────────────────────────────────────────────────────────────────────
   # Settings → General
@@ -118,7 +118,39 @@ branches:
 # https://github.com/github/ruleset-recipes
 #───────────────────────────────────────────────────────────────────────────────
 rulesets:
-  - name: Codeowner code reviews
+  - name: Branch names must be OS-compatible
+    target: branch
+    enforcement: active
+    bypass_actors: []
+    conditions:
+      ref_name:
+        include: [~ALL]
+        exclude: []
+    rules:
+      - type: branch_name_pattern
+        parameters:
+          name: Allowed characters
+          negate: false
+          operator: regex
+          pattern: "^[\\w/-]+$"
+
+  - name: Use Conventional Commits
+    target: branch
+    enforcement: active
+    bypass_actors: []
+    conditions:
+      ref_name:
+        include: [~DEFAULT_BRANCH]
+        exclude: []
+    rules:
+      - type: commit_message_pattern
+        parameters:
+          name:
+          negate: false
+          operator: regex
+          pattern: "^(build|chore|ci|docs|feat|fix|infra|perf|refactor|revert|style|test){1}(\\([\\w\\-\\.]+\\))?(!)?: ([\\w ])+([\\s\\S]*)"
+
+  - name: Review each PR
     target: branch
     enforcement: active
     bypass_actors:
@@ -137,16 +169,6 @@ rulesets:
           require_code_owner_review: true
           require_last_push_approval: false
           required_review_thread_resolution: true
-
-  - name: Copilot code reviews
-    target: branch
-    enforcement: active
-    bypass_actors: []
-    conditions:
-      ref_name:
-        include: [~DEFAULT_BRANCH]
-        exclude: []
-    rules:
       - type: copilot_code_review
         parameters:
           review_on_push: true
@@ -163,6 +185,7 @@ rulesets:
     rules:
       - type: deletion
       - type: non_fast_forward
+      - type: required_linear_history
 
   - name: Protect version tags
     target: tag
@@ -240,7 +263,7 @@ labels:
     description: Functionality-breaking changes
 
   - name: critical
-    color: "#1a0000"
+    color: "#ff0000"
     description: Highest priority
 
   - name: invalid

--- a/.github/workflows/template-sync.yml
+++ b/.github/workflows/template-sync.yml
@@ -3,9 +3,9 @@
 name: Template Sync
 
 on:
-  # Runs daily at midnight (https://crontab.guru/#0_0_1_*_*)
+  # Runs nightly at midnight UTC (https://crontab.guru/#0_0_*_*_*)
   # schedule:
-  #   - cron: "0 0 1 * *"
+  #   - cron: "0 0 * * *"
 
   # Can be triggered manually
   workflow_dispatch:
@@ -82,5 +82,5 @@ jobs:
             Automated sync from template repo.
 
             ${{ steps.merge.outputs.conflict == 'true' && '⚠️ **This PR contains merge conflicts that need to be resolved manually before merging.**' || '' }}
-          labels: "${{ steps.merge.outputs.conflict == 'true' && 'template sync,needs resolution' || 'template sync' }}"
+          labels: "${{ steps.merge.outputs.conflict == 'true' && 'template sync,needs fix' || 'template sync' }}"
           delete-branch: true

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ title: Personal GitHub Repo Structure
 flowchart TB
 
   subgraph row1 [" "]
-    github(**.github**
+    github(<b>.github</b>
     repo)
 
     githubNote[Contains core files
@@ -23,12 +23,12 @@ flowchart TB
   end
 
   subgraph row2 [" "]
-    templateA(**.template-a**
+    templateA(<b>.template-a</b>
     repo)
 
-    repo1(repo 1)
+    repo1(repo-1)
 
-    templateB(**.template-b**
+    templateB(<b>.template-b</b>
     repo)
 
     templateNote[Templates contain
@@ -37,16 +37,16 @@ flowchart TB
   end
 
   subgraph row3 [" "]
-    repo2(repo 2)
-    repo3(repo 3)
-    repo4(repo 4)
+    repo2(repo-2)
+    repo3(repo-3)
+    repo4(repo-4)
 
-    templateC(**.template-c**
+    templateC(<b>.template-c</b>
     repo)
   end
 
   subgraph row4 [" "]
-    repo5(repo 5)
+    repo5(repo-5)
   end
 
   classDef row opacity:0
@@ -91,7 +91,7 @@ because most files need repo-specific customization.
 
 ### [Community Health][ghComHealth]
 
-| File                                | Exists only in</br>.github repo | Overridden in<br/>template repo | Notes                    |
+| File                                | Exists only in<br/>.github repo | Overridden in<br/>template repo | Notes                    |
 | :---------------------------------- | :-----------------------------: | :-----------------------------: | :----------------------- |
 | 📁[.github/][githubFolder]           |                                 |                                 |                          |
 | &nbsp;├─📄[CODEOWNERS][codeOwnFile]  |               N/A               |                ✅                |                          |
@@ -103,9 +103,9 @@ because most files need repo-specific customization.
 | 📄[SECURITY.md][securityFile]        |                                 |                ✅                | Links to GitHub repo     |
 | 📄[SUPPORT.md][supportFile]          |                                 |                ✅                | Links to other files     |
 
-### [GitHub Configuration][ghTemplates]
+### GitHub Configuration
 
-| Template                                                         | Exists only in</br>.github repo | Overridden in<br/>template repo | Description                                     |
+| Template                                                         | Exists only in<br/>.github repo | Overridden in<br/>template repo | Description                                     |
 | :--------------------------------------------------------------- | :-----------------------------: | :-----------------------------: | :---------------------------------------------- |
 | 📁[.github/][githubFolder]                                        |                                 |                                 |                                                 |
 | &nbsp;├─📁DISCUSSION_TEMPLATE/                                    |                —                |                —                | Not implemented                                 |
@@ -177,7 +177,7 @@ because most files need repo-specific customization.
 [ghCopilot]: https://docs.github.com/en/copilot/customizing-copilot/adding-repository-custom-instructions-for-github-copilot
 [ghDependabot]: https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference
 [ghIssueChooser]: https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository#configuring-the-template-chooser
-[ghIssueForms]: https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/manually-creating-a-single-issue-template-for-your-repositoryhttps://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-issue-forms
+[ghIssueForms]: https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-issue-forms
 [ghPRTemplate]: https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository
 [ghTemplates]: https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository
 [ghWorkflows]: https://docs.github.com/en/actions/how-tos/writing-workflows

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -19,7 +19,7 @@ Spending the extra time up front can help save everyone time in the long run.
 Here are some tips:
 
 - First, [talk to a duck][rubberDuck]!
-- Don’t fall for the [XY problem][xyProblem]
+- Don't fall for the [XY problem][xyProblem]
 - Search to find out if a similar question has been asked
   - The [Documentation][docsFolder] and [Wiki][ghWiki] are great places to start
   - A [Discussion][ghDiscussions] or [Issue][ghIssues]
@@ -29,9 +29,9 @@ Here are some tips:
   - Is there something in particular you want to do?
   - What problem are you encountering,
     and what steps have you taken to try to fix it?
-  - Is there a concept you don’t understand?
+  - Is there a concept you don't understand?
 - Provide sample code, such as a [CodeSandbox][codeSandbox] or video, if possible
-- Screenshots can help, but if there’s important text
+- Screenshots can help, but if there's important text
   such as code or error messages in them,
   please also provide them as text to make them more searchable
 - The more time you put into asking your question, the better we can help you!

--- a/_checklist.md
+++ b/_checklist.md
@@ -1,9 +1,9 @@
-# Creating a New Template Repo <!-- omit in toc -->
+# Creating a New Template Repo <!-- omit from toc -->
 
 Template repos use the [.github][ghTemplate] repo as their base template.
 Follow these steps to create a new template repo derived from it.
 
-#### Table of Contents <!-- omit in toc -->
+#### Table of Contents <!-- omit from toc -->
 
 - [1. Create the new repo](#1-create-the-new-repo)
 - [2. Configure manual repo settings](#2-configure-manual-repo-settings)

--- a/docs/Styleguide.md
+++ b/docs/Styleguide.md
@@ -159,7 +159,7 @@ See the [local documentation][ccFile] for more information.
 <!-- Source Code URIs (alphabetical by file hierarchy) -->
 
 [ccFile]: ./ConventionalCommits.md
-[rulersFile]: ./docs/VerticalRulers.md
+[rulersFile]: ./VerticalRulers.md
 [editorConfigFile]: ../.editorconfig
 [gitAttributesFile]: ../.gitattributes
 


### PR DESCRIPTION
## Summary

Repo-review cleanup for the `.github` community-health repository, split into
two commits: infrastructure/config refinements and documentation fixes.

### Infrastructure & config
- Rulesets: split and renamed branch rulesets (OS-compatible branch names,
  Conventional Commits, per-PR review); added required_linear_history
- Topics: dropped noisy github/template catch-alls, swapped community-health
  for community-health-files, added probot-settings, kept template-repository
- Labels: recolored the "critical" label from near-black to red
- template-sync: nightly instead of monthly; conflicted sync PRs labeled
  "needs fix" (defined) instead of undefined "needs resolution"

### Documentation
- README: repaired malformed issue-forms link, valid <br/> in table headers,
  unlinked the "GitHub Configuration" heading, Mermaid labels via <b> tags
- Styleguide: fixed the VerticalRulers link that resolved to docs/docs/
- SUPPORT: normalized curly apostrophes to straight
- _checklist: switched to the current "omit from toc" directive