### PR TITLE
Fix ruleset regexes

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -132,47 +132,7 @@ rulesets:
           name: Allowed characters
           negate: false
           operator: regex
-          pattern: "^[\\w/-]+$"
-
-  - name: Use Conventional Commits
-    target: branch
-    enforcement: active
-    bypass_actors: []
-    conditions:
-      ref_name:
-        include: [~DEFAULT_BRANCH]
-        exclude: []
-    rules:
-      - type: commit_message_pattern
-        parameters:
-          name:
-          negate: false
-          operator: regex
-          pattern: "^(build|chore|ci|docs|feat|fix|infra|perf|refactor|revert|style|test){1}(\\([\\w\\-\\.]+\\))?(!)?: ([\\w ])+([\\s\\S]*)"
-
-  - name: Review each PR
-    target: branch
-    enforcement: active
-    bypass_actors:
-      - actor_id: 5 # Repository admin
-        actor_type: RepositoryRole
-        bypass_mode: pull_request
-    conditions:
-      ref_name:
-        include: [~DEFAULT_BRANCH]
-        exclude: []
-    rules:
-      - type: pull_request
-        parameters:
-          required_approving_review_count: 0
-          dismiss_stale_reviews_on_push: true
-          require_code_owner_review: true
-          require_last_push_approval: false
-          required_review_thread_resolution: true
-      - type: copilot_code_review
-        parameters:
-          review_on_push: true
-          review_draft_pull_requests: true
+          pattern: "\\A[\\w/-]+\\z"
 
   - name: Protect default branch history
     target: branch
@@ -199,6 +159,30 @@ rulesets:
       - type: deletion
       - type: non_fast_forward
 
+  - name: Review each PR
+    target: branch
+    enforcement: active
+    bypass_actors:
+      - actor_id: 5 # Repository admin
+        actor_type: RepositoryRole
+        bypass_mode: pull_request
+    conditions:
+      ref_name:
+        include: [~DEFAULT_BRANCH]
+        exclude: []
+    rules:
+      - type: pull_request
+        parameters:
+          required_approving_review_count: 0
+          dismiss_stale_reviews_on_push: true
+          require_code_owner_review: true
+          require_last_push_approval: false
+          required_review_thread_resolution: true
+      - type: copilot_code_review
+        parameters:
+          review_on_push: true
+          review_draft_pull_requests: true
+
   - name: Status checks must pass
     target: branch
     enforcement: active
@@ -224,6 +208,22 @@ rulesets:
             - tool: CodeQL
               security_alerts_threshold: high_or_higher
               alerts_threshold: errors
+
+  - name: Use Conventional Commits
+    target: branch
+    enforcement: active
+    bypass_actors: []
+    conditions:
+      ref_name:
+        include: [~DEFAULT_BRANCH]
+        exclude: []
+    rules:
+      - type: commit_message_pattern
+        parameters:
+          name: Conventional Commits
+          negate: false
+          operator: regex
+          pattern: "\\A(build|chore|ci|docs|feat|fix|infra|perf|refactor|revert|style|test){1}(\\([\\w\\-\\.]+\\))?(!)?: ([\\w ])+([\\s\\S]*)"
 
 #───────────────────────────────────────────────────────────────────────────────
 # Issues → Labels


### PR DESCRIPTION
## Summary

Two ruleset definitions silently failed to apply — the live repo had only 4 of 6 rulesets. Root cause: GitHub validates ruleset regexes as RE2 and rejects the `^`/`$` line-anchors, returning a 422. The repository-settings app fires all ruleset changes through one `Promise.all` with no per-item error handling, so the two failed creates just vanished while the rest applied.

Verified against `r1-development/pythia`, whose byte-identical branch-name ruleset (same name, `~ALL`, empty `bypass_actors`) is live — the only difference was `\A...\z` vs `^...$`.

## Changes
- `branch_name_pattern`: `"^[\w/-]+$"` → `"\A[\w/-]+\z"`
- `commit_message_pattern`: anchored with `\A` instead of `^`, and set the rule's `name` parameter (was YAML `null`, also invalid) to a string

## Not the cause
`required_linear_history` applied fine — it's live on `main`. Ruled out.

## After merge
The Settings app runs on `main`; confirm the live ruleset count goes 4 → 6.