### PR TITLE
Disable org-only metadata rulesets

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -118,21 +118,23 @@ branches:
 # https://github.com/github/ruleset-recipes
 #───────────────────────────────────────────────────────────────────────────────
 rulesets:
-  - name: Branch names must be OS-compatible
-    target: branch
-    enforcement: active
-    bypass_actors: []
-    conditions:
-      ref_name:
-        include: [~ALL]
-        exclude: []
-    rules:
-      - type: branch_name_pattern
-        parameters:
-          name: Allowed characters
-          negate: false
-          operator: regex
-          pattern: "\\A[\\w/-]+\\z"
+  # Metadata-restriction rulesets (branch names, commit messages) apply only on
+  # org-owned repos, not personal accounts. Un-comment on an org.
+  # - name: Branch names must be OS-compatible
+  #   target: branch
+  #   enforcement: active
+  #   bypass_actors: []
+  #   conditions:
+  #     ref_name:
+  #       include: [~ALL]
+  #       exclude: []
+  #   rules:
+  #     - type: branch_name_pattern
+  #       parameters:
+  #         name: Allowed characters
+  #         negate: false
+  #         operator: regex
+  #         pattern: '^[\w/-]+$'
 
   - name: Protect default branch history
     target: branch
@@ -209,21 +211,23 @@ rulesets:
               security_alerts_threshold: high_or_higher
               alerts_threshold: errors
 
-  - name: Use Conventional Commits
-    target: branch
-    enforcement: active
-    bypass_actors: []
-    conditions:
-      ref_name:
-        include: [~DEFAULT_BRANCH]
-        exclude: []
-    rules:
-      - type: commit_message_pattern
-        parameters:
-          name: Conventional Commits
-          negate: false
-          operator: regex
-          pattern: "\\A(build|chore|ci|docs|feat|fix|infra|perf|refactor|revert|style|test){1}(\\([\\w\\-\\.]+\\))?(!)?: ([\\w ])+([\\s\\S]*)"
+  # Metadata-restriction rulesets (branch names, commit messages) apply only on
+  # org-owned repos, not personal accounts. Un-comment on an org.
+  # - name: Use Conventional Commits
+  #   target: branch
+  #   enforcement: active
+  #   bypass_actors: []
+  #   conditions:
+  #     ref_name:
+  #       include: [~DEFAULT_BRANCH]
+  #       exclude: []
+  #   rules:
+  #     - type: commit_message_pattern
+  #       parameters:
+  #         name: Conventional Commits
+  #         negate: false
+  #         operator: regex
+  #         pattern: '^(build|chore|ci|docs|feat|fix|infra|perf|refactor|revert|style|test)(\([\w.-]+\))?(!)?: ([\w ])+([\s\S]*)'
 
 #───────────────────────────────────────────────────────────────────────────────
 # Issues → Labels


### PR DESCRIPTION
## Summary

The `branch_name_pattern` and `commit_message_pattern` rulesets never applied on this repo. GitHub only supports metadata-restriction rules on **organization-owned** repositories, and this is a personal account. On a personal account the Settings app POSTs the ruleset, GitHub returns 422, and the app drops it silently — so only 4 of the 6 defined rulesets ever went live, with no error shown.

Confirmed it's account-type gating, not regex/enforcement: the identical `branch_name_pattern` with `active` enforcement and a `^...$` pattern is live on the org repo `r1-development/file-converter-service`.

## Change

- Comment out both metadata-restriction rulesets, each with a short note.
- Keep the definitions intact (regex in the `^/$` form) so they can be un-commented directly if a repo ever moves to an org.
- The 4 structural rulesets are unchanged.

To enforce these checks on a personal repo instead, use a GitHub Actions check (commitlint for messages, a branch-name guard).